### PR TITLE
Allow for module pre-compilation in Julia 0.5+

### DIFF
--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -31,12 +31,12 @@ const TypeMaps = [
 	("c8", Complex64),
 	("c16", Complex128),
 ]
-Numpy2Julia = Dict{String, DataType}()
+const Numpy2Julia = Dict{String, DataType}()
 for (s,t) in TypeMaps
     Numpy2Julia[s] = t
 end
 
-Julia2Numpy = Dict{DataType, String}()
+const Julia2Numpy = Dict{DataType, String}()
 
 @static if VERSION >= v"0.4.0"
     function __init__()

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module NPZ
 
 # NPZ file format is described in
@@ -36,8 +37,17 @@ for (s,t) in TypeMaps
 end
 
 Julia2Numpy = Dict{DataType, String}()
-for (s,t) in TypeMaps
-    Julia2Numpy[t] = s
+
+@static if VERSION >= v"0.4.0"
+    function __init__()
+        for (s,t) in TypeMaps
+            Julia2Numpy[t] = s
+        end
+    end
+else
+    for (s,t) in TypeMaps
+        Julia2Numpy[t] = s
+    end
 end
 
 # Julia2Numpy is a dictionary that uses Types as keys.
@@ -47,10 +57,6 @@ end
 # not be the same as when it is later run. This can
 # be fixed by rehashing the Dict when the module is
 # loaded.
-
-if VERSION >= v"0.4.0"
-	__init__() = Base.rehash!(Julia2Numpy)
-end
 
 readle(ios::IO, ::Type{UInt16}) = htol(read(ios, UInt16))
 


### PR DESCRIPTION
Since `0.5`, pre-compilation must be opted-in with a `__precompile__()` statement at
the top of the module file. I have added this statement, and have also made a
static if statement that initializes Julia2Numpy after pre-compilation.