### PR TITLE
use v1 instead of v1.5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.0', '1.5']
+        version: ['1.0', '1']
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
         experimental: [false]


### PR DESCRIPTION
v1 will automatically expand to the latest released version, so we won't need to update `ci.yml` at every minor release.