### PR TITLE
function barrier in npzreadarray and introduce readheader

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,15 @@
 name = "NPZ"
 uuid = "15e1cf62-19b3-5cfa-8e77-841668bca605"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-Compat = "≥ 1.0.0"
-ZipFile = "≥ 0.3.0"
-julia = "≥ 0.7.0"
+Compat = "1, 2, 3"
+ZipFile = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -203,7 +203,7 @@ function parseheader(s::AbstractString)
     Header{T}(dict["descr"], dict["fortran_order"], dict["shape"])
 end
 
-function npzreadheader(f::IO)
+function readheader(f::IO)
     @compat b = read!(f, Vector{UInt8}(undef, length(NPYMagic)))
     if b != NPYMagic
         error("not a numpy array file")
@@ -237,7 +237,7 @@ function _npzreadarray(f, hdr::Header{T}) where {T}
 end
 
 function npzreadarray(f::IO)
-    hdr = npzreadheader(f)
+    hdr = readheader(f)
     _npzreadarray(f, hdr)
 end
 
@@ -310,18 +310,18 @@ function npzread(dir::ZipFile.Reader,
             if f.name in vars || _maybetrimext(f.name) in vars)
 end
 
-function npzreadheader(filename::AbstractString, vars...)
+function readheader(filename::AbstractString, vars...)
     # Detect if the file is a numpy npy array file or a npz/zip file.
     f = open(filename)
     @compat b = read!(f, Vector{UInt8}(undef, MaxMagicLen))
 
     if samestart(b, ZIPMagic)
         fz = ZipFile.Reader(filename)
-        data = npzreadheader(fz, vars...)
+        data = readheader(fz, vars...)
         close(fz)
     elseif samestart(b, NPYMagic)
         seekstart(f)
-        data = npzreadheader(f)
+        data = readheader(f)
     else
         close(f)
         error("not a NPY or NPZ/Zip file: $filename")
@@ -330,10 +330,10 @@ function npzreadheader(filename::AbstractString, vars...)
     close(f)
     return data
 end
-function npzreadheader(dir::ZipFile.Reader, 
+function readheader(dir::ZipFile.Reader, 
     vars = map(f -> _maybetrimext(f.name), dir.files))
 
-    Dict(_maybetrimext(f.name) => npzreadheader(f)
+    Dict(_maybetrimext(f.name) => readheader(f)
         for f in dir.files 
             if f.name in vars || _maybetrimext(f.name) in vars)
 end

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -166,6 +166,9 @@ struct Header{T,N,F<:Function}
 end
 
 Header{T}(descr::F, fortran_order, shape::NTuple{N,Int}) where {T,N,F} = Header{T,N,F}(descr, fortran_order, shape)
+Base.size(hdr::Header) = hdr.shape
+Base.eltype(hdr::Header{T}) where T = T
+Base.ndims(hdr::Header{T,N}) where {T,N} = N
 
 function parseheader(s::AbstractString)
     s = parsechar(s, '{')

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -313,6 +313,13 @@ function npzread(dir::ZipFile.Reader,
             if f.name in vars || _maybetrimext(f.name) in vars)
 end
 
+"""
+    readheader(filename, [vars...])
+
+Return a header or a collection of headers corresponding to each variable contained in `filename`. 
+The header contains information about the `eltype` and `size` of the array that may be extracted using 
+the corresponding accessor functions.
+"""
 function readheader(filename::AbstractString, vars...)
     # Detect if the file is a numpy npy array file or a npz/zip file.
     f = open(filename)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,17 +122,20 @@ end
 end
 
 @testset "readheader" begin
-    checksize(a, b) = all(a .== b)
-
     f = tempname()
     arr = zeros(2,3)
     npzwrite(f, arr)
     hdr = readheader(f)
-    @test checksize(hdr.shape, size(arr))
+    @test size(hdr) == size(arr)
+    @test ndims(hdr) == ndims(arr)
+    @test eltype(hdr) == eltype(arr)
 
-    npzwrite(f, ones(2,2), x = ones(3), y = 3)
+    npzwrite(f, ones(2,2), x = ones(Int,3), y = 3)
     hdr = readheader(f)
-    @test checksize(hdr["arr_0"].shape, (2,2))
-    @test checksize(hdr["x"].shape, (3,))
-    @test checksize(hdr["y"].shape, ())
+    @test size(hdr["arr_0"]) == (2,2)
+    @test eltype(hdr["arr_0"]) == eltype(npzread(f, ["arr_0"])["arr_0"])
+    @test size(hdr["x"]) == (3,)
+    @test eltype(hdr["x"]) == eltype(npzread(f, ["x"])["x"])
+    @test size(hdr["y"]) == ()
+    @test eltype(hdr["y"]) == eltype(npzread(f, ["y"])["y"])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using NPZ, Compat
 
-import NPZ: npzreadheader
+import NPZ: readheader
 
 @static if VERSION >= v"0.7.0-DEV.2575"
     using Test
@@ -121,17 +121,17 @@ end
     @test npzread(f) == 0.0
 end
 
-@testset "npzreadheader" begin
+@testset "readheader" begin
     checksize(a, b) = all(a .== b)
 
     f = tempname()
     arr = zeros(2,3)
     npzwrite(f, arr)
-    hdr = npzreadheader(f)
+    hdr = readheader(f)
     @test checksize(hdr.shape, size(arr))
 
     npzwrite(f, ones(2,2), x = ones(3), y = 3)
-    hdr = npzreadheader(f)
+    hdr = readheader(f)
     @test checksize(hdr["arr_0"].shape, (2,2))
     @test checksize(hdr["x"].shape, (3,))
     @test checksize(hdr["y"].shape, ())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using NPZ, Compat
 
+import NPZ: npzreadheader
+
 @static if VERSION >= v"0.7.0-DEV.2575"
     using Test
 else
@@ -117,4 +119,20 @@ end
     f = tempname()
     npzwrite(f, zeros())
     @test npzread(f) == 0.0
+end
+
+@testset "npzreadheader" begin
+    checksize(a, b) = all(a .== b)
+
+    f = tempname()
+    arr = zeros(2,3)
+    npzwrite(f, arr)
+    hdr = npzreadheader(f)
+    @test checksize(hdr.shape, size(arr))
+
+    npzwrite(f, ones(2,2), x = ones(3), y = 3)
+    hdr = npzreadheader(f)
+    @test checksize(hdr["arr_0"].shape, (2,2))
+    @test checksize(hdr["x"].shape, (3,))
+    @test checksize(hdr["y"].shape, ())
 end


### PR DESCRIPTION
This PR does two things:

- Make the `Header` type parametric and concrete: this seems to cut down on allocations while reading arrays

On master:
```julia
julia> npzwrite("abc.npy", ones(3,4));

julia> @btime npzread("abc.npy");
  23.639 μs (91 allocations: 5.80 KiB)
```

After this PR: 
```julia
julia> @btime npzread("abc.npy");
  20.911 μs (80 allocations: 5.28 KiB)
```

The difference in run-time is marginal.

- Introduce a function `readheader` that returns the header. This might be convenient to get the `eltype` and `size` of the array without reading it in (eg. to pre-allocate an array of the correct size). This function is not exported.

```julia
julia> npzwrite("abc.npy", ones(3,4));

julia> NPZ.readheader("abc.npy")
NPZ.Header{Float64,2,typeof(ltoh)}(ltoh, true, (3, 4))

julia> NPZ.readheader("abc.npy") |> size
(3, 4)

julia> NPZ.readheader("abc.npy") |> eltype
Float64
```