### PR TITLE
File io

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.4.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 [compat]
 Compat = "1, 2, 3"
 ZipFile = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+FileIO = "1"
 julia = "0.7, 1"
 
 [extras]

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -4,7 +4,7 @@ module NPZ
 # NPZ file format is described in
 # https://github.com/numpy/numpy/blob/v1.7.0/numpy/lib/format.py
 
-using ZipFile, Compat
+using ZipFile, Compat, FileIO
 
 @static if VERSION >=  v"0.7.0-DEV.2575"
     import Base.CodeUnits
@@ -468,5 +468,8 @@ function npzwrite(filename::AbstractString, args...; kwargs...)
 
     npzwrite(filename, d)
 end
+
+# support for FileIO
+load(file::File{format"NPZ"}, vars...) = npzread(filename(file), vars...)
 
 end # module

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -470,6 +470,7 @@ function npzwrite(filename::AbstractString, args...; kwargs...)
 end
 
 # support for FileIO
+load(file::File{format"NPY"}, vars...) = npzread(filename(file), vars...)
 load(file::File{format"NPZ"}, vars...) = npzread(filename(file), vars...)
 
 end # module

--- a/src/NPZ.jl
+++ b/src/NPZ.jl
@@ -473,4 +473,7 @@ end
 load(file::File{format"NPY"}, vars...) = npzread(filename(file), vars...)
 load(file::File{format"NPZ"}, vars...) = npzread(filename(file), vars...)
 
+save(file::File{format"NPY"}, data, vars...) = npzwrite(filename(file), data, vars...)
+save(file::File{format"NPZ"}, data, vars...) = npzwrite(filename(file), data, vars...)
+
 end # module


### PR DESCRIPTION
Added a convenience function used by FileIO. This makes it easy to work with multiple filetypes at the same time.

Before:
```julia
using FileIO
using NPZ

model = load("model-001.ply")
keypoints = npzread("keypoints.npz", ["001"])
camera = npzread("camera.npy")
```

after
```julia
using FileIO

model = load("model-001.ply")
keypoints = load("keypoints.npz", ["001"])
camera = load("camera.npy")
```

If it can be merged I have changes ready to integrate it with FileIO on their side. 
[FileIO fork](https://github.com/Pan-Maciek/FileIO.jl/tree/NPZ)
[MR](https://github.com/JuliaIO/FileIO.jl/pull/358)