### PR TITLE
Sync ZipFile.jl requirements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NPZ"
 uuid = "15e1cf62-19b3-5cfa-8e77-841668bca605"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -9,7 +9,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 Compat = "1, 2, 3, 4"
-ZipFile = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+ZipFile = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
 FileIO = "1"
 julia = "0.7, 1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NPZ"
 uuid = "15e1cf62-19b3-5cfa-8e77-841668bca605"
-version = "0.4.3"
+version = "0.4.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Adding 0.10 of ZipFile.jl support should not be problematic. As it is commented in #54 having a new release would be good as current version of Compat.jl is 4.x which is currently not allowed by NPZ.jl and it conflicts with many packages.