### PR TITLE
increase version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NPZ"
 uuid = "15e1cf62-19b3-5cfa-8e77-841668bca605"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"


### PR DESCRIPTION
For some reason version 0.4.2 seems to be in the registries already, see https://github.com/fhs/NPZ.jl/commit/bc3a8c680823117068f997f603eafded10380746#commitcomment-90796892
Let's tag 0.4.3 instead