### PR TITLE
bump Documenter to v1.3

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ DocMeta.setdocmeta!(NPZ, :DocTestSetup, :(using NPZ); recursive=true)
 
 makedocs(;
     modules=[NPZ],
-    repo="https://github.com/fhs/NPZ.jl/blob/{commit}{path}#L{line}",
+    repo=Remotes.GitHub("fhs", "NPZ.jl"),
     sitename="NPZ.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",


### PR DESCRIPTION
Documenter v1.3 or newer automatically generates inventories that make it simpler for other projects to [link to the documentation](https://documenter.juliadocs.org/stable/man/guide/#External-Cross-References).

Bump the version of Documenter used to build the docs from v0.27 to v1.3 and fix the one error introduced by breaking changes in Documneter in the since v0.27.